### PR TITLE
New tag with clang-13, gcc-9 and Android NDK r23b

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,0 +1,36 @@
+# Automatically builds docker images and pushes them to the registry.
+# Required drone secrets:
+#   - docker_repo       eg. 'xeniaproject/buildenv'
+#   - docker_username   user with write permissions to repo
+#   - docker_password   password of the user
+
+def main(ctx):
+    return [
+        pipeline('2021-05-05'),
+        pipeline('2021-06-21'),
+        pipeline('2021-09-29'),
+    ]
+
+def pipeline(tag):
+    return {
+        'kind': 'pipeline',
+        'type': 'docker',
+        'name': tag,
+        'steps': [
+            {
+                'name': 'docker',
+                'image': 'plugins/docker',
+                'settings': {
+                  'dockerfile': 'Dockerfile.' + tag,
+                  'tags': [tag],
+                  'repo': {'from_secret': 'docker_repo'},
+                  'username': {'from_secret': 'docker_username'},
+                  'password': {'from_secret': 'docker_password'},
+                },
+            },
+        ],
+        'trigger': {
+            'branch': ['master'],
+            'event': ['push']
+        },
+    }

--- a/.drone.star
+++ b/.drone.star
@@ -8,7 +8,7 @@ def main(ctx):
     return [
         pipeline('2021-05-05'),
         pipeline('2021-06-21'),
-        pipeline('2021-09-29'),
+        pipeline('2022-01-01'),
     ]
 
 def pipeline(tag):

--- a/Dockerfile.2021-09-29
+++ b/Dockerfile.2021-09-29
@@ -1,0 +1,57 @@
+# Linux build environment for CI
+
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends  \
+      build-essential                           \
+      ca-certificates                           \
+      git                                       \
+      gnupg                                     \
+      python3                                   \
+      wget                                      \
+      # clang                                     \
+      g++                                       \
+      # clang-format                              \
+      cmake                                     \
+      # llvm                                      \
+      libc++-dev                                \
+      libc++abi-dev                             \
+      libgtk-3-dev                              \
+      liblz4-dev                                \
+      libpthread-stubs0-dev                     \
+      libsdl2-dev                               \
+      libvulkan-dev                             \
+      libx11-dev                                \
+      libx11-xcb-dev                            \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
+    echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" > /etc/apt/sources.list.d/llvm-13.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      clang-13        \
+      clang-format-13 \
+      llvm-13         \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/clang-format-13 /usr/local/bin/clang-format
+
+RUN set -eux; \
+	{ \
+		echo 'CC=clang-13'; \
+		echo 'CXX=clang++-13'; \
+		echo 'AR=llvm-ar-13'; \
+	} > /clang.env
+
+RUN set -eux; \
+	{ \
+		echo 'CC=gcc'; \
+		echo 'CXX=g++'; \
+	} > /gcc.env

--- a/Dockerfile.2022-01-01
+++ b/Dockerfile.2022-01-01
@@ -1,8 +1,16 @@
-# Linux build environment for CI
+# Linux and Android build environment for CI
 
 FROM ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
+
+ENV ANDROID_NDK_ROOT /opt/android-ndk
+ENV ANDROID_NDK_VERSION r23b
+
+
+#
+# GCC & Clang
+#
 
 RUN set -eux; \
     apt-get update; \
@@ -55,3 +63,26 @@ RUN set -eux; \
 		echo 'CC=gcc'; \
 		echo 'CXX=g++'; \
 	} > /gcc.env
+
+
+#
+# Android NDK
+#
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends  \
+      file                                      \
+      unzip                                     \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /tmp/android-ndk && \
+    cd /tmp/android-ndk && \
+    \
+    wget -q -O android-ndk.zip https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip && \
+    \
+    unzip -q android-ndk.zip && \
+    \
+    mv ./android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_ROOT}
+RUN rm -rf /tmp/android-ndk


### PR DESCRIPTION
What's new:

- `clang-13` ~~(in RC right now, therefore draft PR)~~
- `gcc-9` (ubuntu focal standard compiler)
- `.env` files for selection of compiler at runtime
- `NDK r23b` for Android

Required changes:

- Activate the buildenv repository in Drone CI (Docker hub ceased free auto-builds)
- In the Drone project settings, set the configuration file to `.drone.star` and disable forks and pull requests
- To be able to push the image from Drone CI to docker hub, populate the required secrets in the Drone project settings:
  - docker_repo  `xeniaproject/buildenv`
  - docker_username   user with write permissions to the buildenv docker hub repo
  - docker_password 